### PR TITLE
Running the whole test suite causes tests to fail after the redis config is set

### DIFF
--- a/tests/test_redis_config.py
+++ b/tests/test_redis_config.py
@@ -25,8 +25,9 @@ def test_load_with_redis_does_not_call_yaml_load(get_redis_cache, yaml_load):
     assert config.yaml['foo'] == 'bar'
 
 
+@mock.patch.object(cc_dynamodb3.config, '_redis_config')
 @mock.patch('cc_dynamodb3.config.get_redis_cache')
-def test_load_with_redis_calls_yaml_load_if_cache_miss(get_redis_cache):
+def test_load_with_redis_calls_yaml_load_if_cache_miss(get_redis_cache, _redis_config):
     redis_mock = mock.Mock()
     redis_mock.get = lambda key: None
     get_redis_cache.return_value = redis_mock


### PR DESCRIPTION
Running the whole test suite causes tests to fail after the redis config  (cc_dynamodb3.config._redis_config) is set. This object was not being mocked out, so leftover state messed up subsequent tests. This fix mocks out the object for the one test that sets the redis config.