### PR TITLE
Update test requirements to reference an official release of the moto…

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,5 +3,5 @@ factory-boy==2.6.0
 mock==1.0.1
 pytest==2.7.0
 pytest-cov==1.8.1
-git+https://github.com/spulec/moto.git@35478f3a4414c03e68abd179d44f3ba3a80d5767#egg=moto
+git+https://github.com/spulec/moto.git@0.4.23#egg=moto
 -e .


### PR DESCRIPTION
… AWS mocks library. Previously a specific commit was referenced for needed updates to support boto3. The official release incorporates those needed fixes to moto as well as other necessary fixes.