### PR TITLE
Allow building of DynamoDBModel without saving.

### DIFF
--- a/cc_dynamodb3/models.py
+++ b/cc_dynamodb3/models.py
@@ -179,9 +179,13 @@ class DynamoDBModel(Model):
             yield cls.from_row(row, metadata)
 
     @classmethod
-    def create(cls, **kwargs):
+    def build(cls, **kwargs):
         dynamodb_data = cls._initial_data_to_dynamodb(kwargs)
-        model = cls(dynamodb_data)
+        return cls(dynamodb_data)
+
+    @classmethod
+    def create(cls, **kwargs):
+        model = cls.build(**kwargs)
         model.save(overwrite=True)
         return model
 


### PR DESCRIPTION
@pcraciunoiu 

https://clearcare.atlassian.net/browse/CC-14464 - There are potentially 3 writes to dynamodb during the telephony `/incoming` request. This can be reduced to 1 if we create the Telephony session at the last possible moment in the view. To do that, it'd be nice to build the session object without the initial save.