### PR TITLE
WSPC-15565 fix bunch py3.11 incompatibility

### DIFF
--- a/cc_dynamodb3/config.py
+++ b/cc_dynamodb3/config.py
@@ -2,7 +2,7 @@ import copy
 import json
 import os
 
-from bunch import Bunch
+from munch import Munch
 import redis
 import yaml
 
@@ -86,7 +86,7 @@ def set_config(config_file_path, namespace=None, aws_access_key_id=False, aws_se
 
     yaml_config = load_yaml_config()
 
-    _cached_config = Bunch({
+    _cached_config = Munch({
         'yaml': yaml_config,
         'namespace': namespace
                         or os.environ.get('CC_DYNAMODB_NAMESPACE'),
@@ -150,4 +150,4 @@ def get_config(**kwargs):
         # be invoked before calling get_config().
         set_config(**kwargs)
 
-    return Bunch(copy.deepcopy(_cached_config.toDict()))
+    return Munch(copy.deepcopy(_cached_config.toDict()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bunch>=1.0.1
+munch>=4.0.0
 boto3==1.2.2
 PyYAML>=3.10
 schematics==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'cc_dynamodb3',
     packages=find_packages(),
     install_requires=[
-        'bunch>=1.0.1',
+        'munch>=4.0.0',
         'boto3>=1.2.2',
         'PyYAML==3.10',
         'schematics==1.1.1',


### PR DESCRIPTION
The upstream bunch package is broken in python3.11. "bunch" no longer gets updates, and has been abandoned by its creator. The fork "munch" fixes the issues.